### PR TITLE
Allow extraction of badly packaged ofp files

### DIFF
--- a/ofp_qc_decrypt.py
+++ b/ofp_qc_decrypt.py
@@ -2,7 +2,7 @@
 # (c) B.Kerler 2018-2021, MIT license
 import os
 import sys
-import xml.etree.ElementTree as ET
+from lxml import etree
 import zipfile
 from struct import unpack
 from binascii import unhexlify, hexlify
@@ -303,7 +303,7 @@ def main():
         print("Unknown key. Aborting")
         exit(0)
     else:
-        xml=data[:data.rfind(b">")+1].decode('utf-8')
+        xml=data[:data.rfind(b">")+1].decode('latin-1')
 
     if "/" in filename:
         path = filename[:filename.rfind("/")]
@@ -325,7 +325,8 @@ def main():
     file_handle.write(xml)
     file_handle.close()
     
-    root = ET.fromstring(xml)
+    parser = etree.XMLParser(recover=True)
+    root = etree.fromstring(xml, parser=parser)
     for child in root:
         for item in child:
             if "Path" not in item.attrib and "filename" not in item.attrib:


### PR DESCRIPTION
Some ofp files contain bad data in their xml files (e.g. Chinese characters) that are not utf-8. This throws the following error:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xde in position 29864: invalid continuation byte

Fix it by using latin-1 and enabling recover in etree.